### PR TITLE
Update Profiler to Match Clang 18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 build/
 tests/
+venv/

--- a/creal.py
+++ b/creal.py
@@ -245,22 +245,29 @@ def run_one(compilers:list[str], dst_dir:Path, SYNER:Synthesizer) -> Path | None
 
 
 if __name__=='__main__':
+    import time
+
     parser = argparse.ArgumentParser(description="Generate a number of realsmith mutants for evaluation.")
     parser.add_argument("--dst", required=True, type=Path, help="Destination directory for generated seeds.")
     parser.add_argument("--syn-prob", required=True, type=int, help="Synthesis probability")
     parser.add_argument("--num-mutants", required=True, type=int, help="The number of mutants per seed by realsmith")
     parser.add_argument("--func-db", default=FUNCTION_DB_FILE, type=str, help="Path to the functiondb file")
+    parser.add_argument("--rand-seed", default=time.time_ns(), type=int, help="Randomness seed")
+    parser.add_argument("--verbose", default=False, action='store_true', help="Verbose or not")
     args = parser.parse_args()
 
     dst_dir = Path(args.dst)
     dst_dir.mkdir(parents=True, exist_ok=True)
 
     NUM_MUTANTS = args.num_mutants
+    DEBUG = 1 if args.verbose else 0
 
     if not os.path.exists(args.func_db):
         print(f"File {args.func_db} does not exist!")
         parser.print_help()
         exit(1)
+
+    random.seed(args.rand_seed)
 
     compilers = [
         "gcc -O0",

--- a/creal.py
+++ b/creal.py
@@ -234,8 +234,8 @@ def run_one(compilers:list[str], dst_dir:Path, SYNER:Synthesizer) -> Path | None
     # synthesize
     try:
         syn_files = SYNER.synthesizer(src_filename=src, num_mutant=NUM_MUTANTS, DEBUG=DEBUG)
-    except:
-        print('SynthesizerError!')
+    except Exception as e:
+        print('SynthesizerError:', e if e else '<no-output>')
         os.remove(src)
         return 0
 
@@ -249,6 +249,7 @@ if __name__=='__main__':
     parser.add_argument("--dst", required=True, type=Path, help="Destination directory for generated seeds.")
     parser.add_argument("--syn-prob", required=True, type=int, help="Synthesis probability")
     parser.add_argument("--num-mutants", required=True, type=int, help="The number of mutants per seed by realsmith")
+    parser.add_argument("--func-db", default=FUNCTION_DB_FILE, type=str, help="Path to the functiondb file")
     args = parser.parse_args()
 
     dst_dir = Path(args.dst)
@@ -256,11 +257,16 @@ if __name__=='__main__':
 
     NUM_MUTANTS = args.num_mutants
 
+    if not os.path.exists(args.func_db):
+        print(f"File {args.func_db} does not exist!")
+        parser.print_help()
+        exit(1)
+
     compilers = [
         "gcc -O0",
         "clang -O0"
     ]
-    SYNER = Synthesizer(func_database=FUNCTION_DB_FILE, prob=args.syn_prob)
+    SYNER = Synthesizer(func_database=args.func_db, prob=args.syn_prob)
     with TempDirEnv() as tmp_dir:
         os.environ['TMPDIR'] = tmp_dir.absolute().as_posix()
         total = 0

--- a/generate_mutants.py
+++ b/generate_mutants.py
@@ -216,23 +216,30 @@ def run_one(seed: str, compilers:list[str], dst_dir:Path, SYNER:Synthesizer, suc
 
 
 if __name__=='__main__':
+    import time
+
     parser = argparse.ArgumentParser(description="Generate a number of realsmith mutants for evaluation.")
     parser.add_argument("--seed", required=True, type=Path, help="the seed.")
     parser.add_argument("--dst", required=True, type=Path, help="Destination directory for generated seeds.")
     parser.add_argument("--syn-prob", required=True, type=int, help="Synthesis probability")
     parser.add_argument("--num-mutants", required=True, type=int, help="The number of mutants per seed by realsmith")
     parser.add_argument("--func-db", default=FUNCTION_DB_FILE, type=str, help="Path to the functiondb file")
+    parser.add_argument("--rand-seed", default=time.time_ns(), type=int, help="Randomness seed")
+    parser.add_argument("--verbose", default=False, action='store_true', help="Verbose or not")
     args = parser.parse_args()
 
     dst_dir = Path(args.dst)
     dst_dir.mkdir(parents=True, exist_ok=True)
 
     NUM_MUTANTS = args.num_mutants
+    DEBUG = 1 if args.verbose else 0
 
     if not os.path.exists(args.func_db):
         print(f"File {args.func_db} does not exist!")
         parser.print_help()
         exit(1)
+
+    random.seed(args.rand_seed)
 
     compilers = [
         "gcc -O0",

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -13,8 +13,8 @@ message(STATUS "Using ClangConfig.cmake in ${Clang_DIR}")
 list(APPEND CMAKE_MODULE_PATH ${CLANG_CMAKE_DIR})
 include(${CLANG_CMAKE_DIR}/AddClang.cmake)
 
-if("${LLVM_VERSION_MAJOR}" VERSION_LESS 13)
-  message(FATAL_ERROR "Found LLVM ${LLVM_VERSION_MAJOR}, but need LLVM >= 13")
+if("${LLVM_VERSION_MAJOR}" VERSION_LESS 18)
+  message(FATAL_ERROR "Found LLVM ${LLVM_VERSION_MAJOR}, but need LLVM >= 18")
 endif()
 
 

--- a/profiler/src/GlobalMacro.cpp
+++ b/profiler/src/GlobalMacro.cpp
@@ -45,7 +45,7 @@ class AddGlobalMacro : public MatchComputation<std::string> {
     }
 };
 
-struct clang::transformer::RewriteRule AddGlobalMacroRule() {
+clang::transformer::RewriteRule AddGlobalMacroRule() {
     return makeRule(functionDecl(
         isExpansionInMainFile(),
         isMain()

--- a/profiler/src/GlobalMacro.hpp
+++ b/profiler/src/GlobalMacro.hpp
@@ -4,6 +4,6 @@
 
 namespace globalmacro {
 
-struct clang::transformer::RewriteRule AddGlobalMacroRule(void);
+clang::transformer::RewriteRule AddGlobalMacroRule(void);
 
 }

--- a/profiler/src/RuleActionCallback.cpp
+++ b/profiler/src/RuleActionCallback.cpp
@@ -25,8 +25,8 @@ std::string GetFilenameFromRange(const CharSourceRange &R,
                                 const SourceManager &SM) {
     const std::pair<FileID, unsigned> DecomposedLocation =
         SM.getDecomposedLoc(SM.getSpellingLoc(R.getBegin()));
-    const FileEntry *Entry = SM.getFileEntryForID(DecomposedLocation.first);
-return std::string(Entry ? Entry->getName() : "");
+    auto Entry = SM.getFileEntryRefForID(DecomposedLocation.first);
+    return Entry ? std::string(Entry->getName()) : "";
 
 }
 
@@ -70,8 +70,8 @@ void ruleactioncallback::RuleActionCallback::run(
         llvm::errs() << "An error has occured.\n";
         return;
     }
-    Expected<SmallVector<transformer::Edit, 1>> Edits =
-        transformer::detail::findSelectedCase(Result, Rule).Edits(Result);
+    size_t I = transformer::detail::findSelectedCase(Result, Rule);
+    Expected<SmallVector<transformer::Edit, 1>> Edits = Rule.Cases[I].Edits(Result);
     if (!Edits) {
         llvm::errs() << "Rewrite failed: " << llvm::toString(Edits.takeError())
                      << "\n";

--- a/profiler/src/TagExpression.cpp
+++ b/profiler/src/TagExpression.cpp
@@ -183,7 +183,7 @@ auto statementMatcher = expr(
 );
 
 
-struct clang::transformer::RewriteRule TagExpressionRule() {
+clang::transformer::RewriteRule TagExpressionRule() {
     return makeRule(matcher, {
         insertBefore(node("expr"), std::make_unique<TagExpressionAction>()),
         insertAfter(node("expr"), cat(")")),
@@ -192,7 +192,7 @@ struct clang::transformer::RewriteRule TagExpressionRule() {
     });
 }
 
-struct clang::transformer::RewriteRule TagStatementRule() {
+clang::transformer::RewriteRule TagStatementRule() {
     return makeRule(statementMatcher, {
         insertBefore(node("stmt"), std::make_unique<TagExpressionAction>()),
         insertAfter(node("stmt"), cat(")"))

--- a/profiler/src/TagExpression.hpp
+++ b/profiler/src/TagExpression.hpp
@@ -6,7 +6,7 @@ namespace tagexpression {
 
 extern std::map<int, std::string> Tags; // <id, type>
 
-struct clang::transformer::RewriteRule TagExpressionRule();
-struct clang::transformer::RewriteRule TagStatementRule();
+clang::transformer::RewriteRule TagExpressionRule();
+clang::transformer::RewriteRule TagStatementRule();
 
 }

--- a/synthesizer/synthesizer.py
+++ b/synthesizer/synthesizer.py
@@ -591,6 +591,6 @@ if __name__=='__main__':
 
     syner = Synthesizer(args.DB, prob=100)
     try:
-        all_syn_files = syner.synthesizer(args.SRC, num_mutant=1, DEBUG=1)
+        all_syn_files = syner.synthesizer(args.SRC, num_mutant=1)
     except SynthesizerError:
         print("SynthesizerError (OK).")

--- a/synthesizer/synthesizer.py
+++ b/synthesizer/synthesizer.py
@@ -569,7 +569,7 @@ return v0; \
                 if not self.tags[tag_id].tag_var.is_stable:
                     continue
                 # randomly decide if we want to replace this value
-                if tag_id in replaced_valuetag or random.randint(0, 100) > self.prob:
+                if tag_id in replaced_valuetag or random.randint(0, 100) < self.prob:
                     continue #skip this value
                 # randomly select a function from database
                 while True:


### PR DESCRIPTION
This PR makes the follow changes:
- **Major**: The profiler module was updated to match clang-18. Note that, the databaseconstructor module was not updated and tested.
- **Major**: Only allow tag replacement if the tag is stable
- _Minor_: Parsing `Tag(...)`s generated by the profiler was updated to support 1-recursive tags for example: `Tag100(Tag101(...))`;
- _Minor_: Functions are inserted as a prologue of the seed program, insead of inserting them after the very last header.
- _Minor_: A `--func-db` option was added to `creal.py` and `generate_mutants.py` to allow to pass a customized function database. There're also new `--rand-seed` for controling the randomness seed and `--verbose` for enabling/disabling DEBUG output.
- _Minor_: Fix the wrong probaility testing condition